### PR TITLE
Remove auth process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ gem 'minitest-rg'
 
 gem 'pry-coolline'
 
+gem 'rake'
 gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     pry-coolline (0.2.5)
       coolline (~> 0.5)
     rainbow (2.1.0)
+    rake (11.3.0)
     rubocop (0.44.1)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
@@ -34,10 +35,11 @@ DEPENDENCIES
   minitest
   minitest-rg
   pry-coolline
+  rake
   rubocop
 
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.3
+   1.13.4

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 ## Usage
 
-```bash
-$ ruby script.rb
-```
+1. Get application access token
+
+  - Fill in `api_key` and `api_secret` in `config/credentials.yml`
+  - Run `rake util:access_token`
+  - Fill in the `access_token` in `config/credentials.yml`
+
+2. Run tests
+
+  ```bash
+  $ ruby spec/twitter/client_spec.rb
+  ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'httparty'
+
+namespace :util do
+  desc 'Generate new access token'
+  task :access_token do
+    OAUTH_ENDPOINT = 'https://api.twitter.com/oauth2/token'
+    credentials = YAML.load_file('config/credentials.yml')
+    basic_token = Base64.urlsafe_encode64("#{credentials['api_key']}:#{credentials['api_secret']}")
+    token_response = HTTParty.post(OAUTH_ENDPOINT, headers: { Authorization: "Basic #{basic_token}" },
+                                                   query: { grant_type: 'client_credentials' }).parsed_response
+    puts "Access Token: #{token_response['access_token']}"
+  end
+end

--- a/config/credentials.example.yml
+++ b/config/credentials.example.yml
@@ -1,2 +1,3 @@
-api_key: <your_api_key>
-api_secret: <your_api_secret>
+api_key: <OPTIONAL your_api_key>
+api_secret: <OPTIONAL your_api_secret>
+access_token: <your_access_token>

--- a/lib/twitter/client.rb
+++ b/lib/twitter/client.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'yaml'
-require 'base64'
 require 'httparty'
 
 module Twitter
@@ -8,11 +7,9 @@ module Twitter
     API_BASE = 'https://api.twitter.com/'
     API_VERSION = '1.1/'
     SEARCH_TWEET_ENDPOINT = URI.join(API_BASE, API_VERSION, 'search/tweets.json')
-    OAUTH_ENDPOINT = URI.join(API_BASE, 'oauth2/token')
 
-    def initialize(api_key:, api_secret:)
-      @api_key = api_key
-      @api_secret = api_secret
+    def initialize(access_token:)
+      @access_token = access_token
     end
 
     def search_tweets(*tags)
@@ -23,20 +20,8 @@ module Twitter
 
     private
 
-    def oauth_token
-      @oauth_token ||= Base64.urlsafe_encode64("#{@api_key}:#{@api_secret}")
-    end
-
-    def authorization_response
-      @authorization_response ||= HTTParty.post(OAUTH_ENDPOINT,
-                                                headers: { Authorization: "Basic #{oauth_token}" },
-                                                query: { grant_type: 'client_credentials' }).parsed_response
-    end
-
     def authorization_header
-      @authorization_header ||= {
-        Authorization: "#{authorization_response['token_type'].capitalize} #{authorization_response['access_token']}"
-      }
+      @authorization_header ||= { Authorization: "Bearer #{@access_token}" }
     end
   end
 end

--- a/spec/twitter/client_spec.rb
+++ b/spec/twitter/client_spec.rb
@@ -9,7 +9,7 @@ tags = '#food'
 
 describe 'Twitter::Client#search_tweets' do
   it 'should return Tweets that contain specific hashtags' do
-    client = Twitter::Client.new(api_key: CREDENTIALS['api_key'], api_secret: CREDENTIALS['api_secret'])
+    client = Twitter::Client.new(access_token: CREDENTIALS['access_token'])
     client.search_tweets(tags).wont_be_nil
   end
 end


### PR DESCRIPTION
As per [Twitter documentation](https://dev.twitter.com/oauth/overview/faq) states:

> How long does an access token last? _We do not currently expire access tokens._

We don't need to OAuth flow in our lib. I've put the flow into a `rake` task.

/cc @edsong1257 @Leoli0320 
